### PR TITLE
feat: add custom API layer + admin panel for ImgBed D1 integration

### DIFF
--- a/CUSTOM_DEPLOY.md
+++ b/CUSTOM_DEPLOY.md
@@ -1,0 +1,118 @@
+# 壁纸库自定义版 - 部署说明
+
+## 分支说明
+
+| 分支 | 用途 |
+|------|------|
+| `main` | 跟踪上游 IT-NuanxinPro/wallpaper-gallery，只同步不修改 |
+| `custom` | **生产分支**，所有自定义改动在此，CF Pages 绑定此分支 |
+
+## 新增文件清单（不修改原有文件）
+
+```
+functions/
+  api/
+    file/[[path]].js     图片代理（隐藏 Bot Token，支持缩略图）
+    wallpapers.js        壁纸列表接口（直查 D1）
+    random.js            随机图接口
+    admin/
+      auth.js            管理员登录/验证
+      config.js          API 配置读写
+  admin.js               后台管理页面路由
+
+src/
+  services/imgbed/
+    api.js               数据服务层（调用 /api/wallpapers）
+  stores/
+    imgbed.js            Pinia store（替代原 wallpaper store 数据加载）
+  views/admin/
+    index.html           后台管理界面（独立 HTML，无需构建）
+```
+
+## CF Pages 配置
+
+### 1. 构建设置
+| 项目 | 值 |
+|------|----|
+| 生产分支 | `custom` |
+| 构建命令 | `npm install && npm run build` |
+| 输出目录 | `dist` |
+
+### 2. D1 数据库绑定
+| 变量名 | 绑定 |
+|--------|------|
+| `DB` | 与 ImgBed 共用的同一个 D1 数据库 |
+
+> ⚠️ 必须和 ImgBed 绑定同一个 D1，变量名必须是 `DB`
+
+### 3. 环境变量
+| 变量名 | 说明 |
+|--------|------|
+| `WG_BOT_TOKENS` | JSON 格式的 chatId→botToken 映射 |
+| `ADMIN_USER` | 管理员用户名（默认 admin） |
+| `ADMIN_PASS` | 管理员密码 |
+| `ADMIN_SECRET` | JWT 签名密钥（32位以上随机字符串） |
+
+**WG_BOT_TOKENS 示例：**
+```json
+{"-1003814998799":"TOKEN1","-1003777271568":"TOKEN2","-1003718954682":"TOKEN3"}
+```
+
+## 管理后台
+
+访问 `/admin` 即可进入，功能包括：
+- 📊 数据概览（各分类图片数量统计）
+- ⚙️ API 配置（缩略图开关、默认筛选规则）
+- 🧪 API 在线测试
+- 🤖 Bot 配置说明
+
+## API 接口速查
+
+| 接口 | 参数 | 说明 |
+|------|------|------|
+| `GET /api/wallpapers` | orientation, style, color, tags, page, limit, random, thumb, thumb_width | 壁纸列表 |
+| `GET /api/random` | type(url/img), orientation, style, color, thumb, w | 随机图 |
+| `GET /api/file/<key>` | w(宽度), q(质量) | 图片代理 |
+| `GET /admin` | — | 后台管理界面 |
+| `POST /api/admin/auth` | {username, password} | 登录 |
+| `GET /api/admin/verify` | Cookie | 验证会话 |
+| `GET/POST /api/admin/config` | — | 读写 API 配置 |
+
+## 与上游同步
+
+```bash
+# 添加上游（只需一次）
+git remote add upstream https://github.com/IT-NuanxinPro/wallpaper-gallery.git
+
+# 上游有更新时
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+
+git checkout custom
+git merge main
+# 若有冲突只会在极少数文件产生，逐个解决即可
+git push origin custom
+```
+
+## 前端接入方式
+
+在需要展示壁纸的 Vue 组件中：
+
+```js
+import { useImgbedStore } from '@/stores/imgbed'
+
+const store = useImgbedStore()
+
+// 加载横图壁纸
+await store.loadWallpapers({ orientation: 'horizontal' })
+
+// 按风格筛选
+await store.applyFilters({ style: '自然_风景', color: '偏蓝' })
+
+// 获取随机壁纸用作背景
+const bg = await store.getRandomWallpaper({ orientation: 'horizontal' })
+// bg.thumbnailUrl → 缩略图（800px WebP）
+// bg.url         → 原图
+```

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -1,0 +1,12 @@
+/**
+ * GET /admin - 管理后台入口
+ * 直接读取并返回 admin/index.html
+ */
+
+export async function onRequest(context) {
+  // CF Pages 静态文件可以通过 ASSETS 访问
+  // 这里直接重定向到 admin 静态文件
+  return context.env.ASSETS.fetch(new Request(
+    new URL('/admin/index.html', context.request.url)
+  ))
+}

--- a/functions/api/admin/auth.js
+++ b/functions/api/admin/auth.js
@@ -1,0 +1,142 @@
+/**
+ * POST /api/admin/login - 管理员登录
+ * POST /api/admin/logout - 登出
+ * GET  /api/admin/verify - 验证会话
+ *
+ * 环境变量：
+ *   ADMIN_USER     管理员用户名
+ *   ADMIN_PASS     管理员密码（明文，建议改为哈希）
+ *   ADMIN_SECRET   JWT签名密钥（随机字符串，至少32位）
+ */
+
+const SESSION_COOKIE = 'wg_admin_session'
+const SESSION_TTL = 7 * 24 * 3600  // 7天
+
+export async function onRequest(context) {
+  const { request, env } = context
+  const url = new URL(request.url)
+  const action = url.pathname.split('/').pop()
+
+  if (request.method === 'OPTIONS') {
+    return corsPrelight()
+  }
+
+  if (action === 'login' && request.method === 'POST') {
+    return handleLogin(request, env)
+  }
+  if (action === 'logout') {
+    return handleLogout()
+  }
+  if (action === 'verify') {
+    return handleVerify(request, env)
+  }
+
+  return new Response('Not found', { status: 404 })
+}
+
+async function handleLogin(request, env) {
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResp({ error: 'Invalid JSON' }, 400)
+  }
+
+  const { username, password } = body
+  const adminUser = env.ADMIN_USER || 'admin'
+  const adminPass = env.ADMIN_PASS || 'changeme'
+
+  if (username !== adminUser || password !== adminPass) {
+    return jsonResp({ error: '用户名或密码错误' }, 401)
+  }
+
+  // 生成简单 session token（生产环境建议用 JWT）
+  const token = await generateToken(env.ADMIN_SECRET || 'default-secret-change-me')
+  const expires = new Date(Date.now() + SESSION_TTL * 1000).toUTCString()
+
+  return new Response(JSON.stringify({ success: true, token }), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Set-Cookie': `${SESSION_COOKIE}=${token}; Path=/; HttpOnly; SameSite=Strict; Expires=${expires}`,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': 'true'
+    }
+  })
+}
+
+function handleLogout() {
+  return new Response(JSON.stringify({ success: true }), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Set-Cookie': `${SESSION_COOKIE}=; Path=/; HttpOnly; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      'Access-Control-Allow-Origin': '*'
+    }
+  })
+}
+
+async function handleVerify(request, env) {
+  const token = getSessionToken(request)
+  if (!token) return jsonResp({ valid: false }, 401)
+
+  const valid = await verifyToken(token, env.ADMIN_SECRET || 'default-secret-change-me')
+  return jsonResp({ valid })
+}
+
+// ---- 工具函数 ----
+
+async function generateToken(secret) {
+  const payload = {
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + SESSION_TTL,
+    role: 'admin'
+  }
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  )
+  const data = btoa(JSON.stringify(payload))
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data))
+  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
+  return `${data}.${sigB64}`
+}
+
+async function verifyToken(token, secret) {
+  try {
+    const [data, sig] = token.split('.')
+    const encoder = new TextEncoder()
+    const key = await crypto.subtle.importKey(
+      'raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']
+    )
+    const sigBytes = Uint8Array.from(atob(sig), c => c.charCodeAt(0))
+    const valid = await crypto.subtle.verify('HMAC', key, sigBytes, encoder.encode(data))
+    if (!valid) return false
+    const payload = JSON.parse(atob(data))
+    return payload.exp > Math.floor(Date.now() / 1000)
+  } catch {
+    return false
+  }
+}
+
+function getSessionToken(request) {
+  const cookie = request.headers.get('Cookie') || ''
+  const match = cookie.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`))
+  return match ? match[1] : null
+}
+
+function jsonResp(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+  })
+}
+
+function corsPrelight() {
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Credentials': 'true'
+    }
+  })
+}

--- a/functions/api/admin/config.js
+++ b/functions/api/admin/config.js
@@ -1,0 +1,125 @@
+/**
+ * GET  /api/admin/config  读取API配置
+ * POST /api/admin/config  保存API配置
+ *
+ * 配置存储在 D1 的 settings 表中（key = 'wg_api_config'）
+ * 如果 settings 表不存在，降级使用内存默认值
+ */
+
+const SESSION_COOKIE = 'wg_admin_session'
+
+export async function onRequest(context) {
+  const { request, env } = context
+
+  if (request.method === 'OPTIONS') {
+    return corsResp()
+  }
+
+  if (!await checkAuth(request, env)) {
+    return jsonResp({ error: '未授权' }, 401)
+  }
+
+  if (request.method === 'GET') return getConfig(env)
+  if (request.method === 'POST') return saveConfig(request, env)
+  return jsonResp({ error: 'Method not allowed' }, 405)
+}
+
+async function getConfig(env) {
+  try {
+    // 尝试从 D1 settings 表读取
+    const result = await env.DB.prepare(
+      "SELECT value FROM settings WHERE key = 'wg_api_config'"
+    ).first()
+    const config = result ? JSON.parse(result.value) : defaultConfig()
+    return jsonResp(config)
+  } catch {
+    return jsonResp(defaultConfig())
+  }
+}
+
+async function saveConfig(request, env) {
+  let body
+  try { body = await request.json() }
+  catch { return jsonResp({ error: 'Invalid JSON' }, 400) }
+
+  const config = { ...defaultConfig(), ...body }
+  const value = JSON.stringify(config)
+
+  try {
+    // INSERT OR REPLACE 写入 D1（settings 表需存在，否则创建）
+    await env.DB.prepare(`
+      CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER DEFAULT (strftime('%s','now'))
+      )
+    `).run()
+
+    await env.DB.prepare(
+      "INSERT OR REPLACE INTO settings (key, value) VALUES ('wg_api_config', ?)"
+    ).bind(value).run()
+
+    return jsonResp({ success: true, config })
+  } catch (e) {
+    return jsonResp({ error: 'Save failed: ' + e.message }, 500)
+  }
+}
+
+function defaultConfig() {
+  return {
+    randomApi: {
+      enabled: true,
+      defaultThumb: true,
+      defaultThumbWidth: 1920,
+      defaultOrientation: '',
+      defaultStyle: '',
+      defaultColor: '',
+      defaultStyles: [],
+      defaultColors: []
+    },
+    gallery: {
+      defaultPageSize: 30,
+      enableSearch: true,
+      enableColorFilter: true,
+      enableStyleFilter: true,
+      showResolution: true
+    }
+  }
+}
+
+async function checkAuth(request, env) {
+  const cookie = request.headers.get('Cookie') || ''
+  const match = cookie.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`))
+  if (!match) return false
+  try {
+    const [data, sig] = match[1].split('.')
+    const secret = env.ADMIN_SECRET || 'default-secret'
+    const encoder = new TextEncoder()
+    const key = await crypto.subtle.importKey(
+      'raw', encoder.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']
+    )
+    const sigBytes = Uint8Array.from(atob(sig), c => c.charCodeAt(0))
+    const valid = await crypto.subtle.verify('HMAC', key, sigBytes, encoder.encode(data))
+    if (!valid) return false
+    const payload = JSON.parse(atob(data))
+    return payload.exp > Math.floor(Date.now() / 1000)
+  } catch { return false }
+}
+
+function jsonResp(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+  })
+}
+
+function corsResp() {
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    }
+  })
+}

--- a/functions/api/file/[[path]].js
+++ b/functions/api/file/[[path]].js
@@ -1,0 +1,107 @@
+/**
+ * GET /api/file/<encoded_key> - 图片代理层
+ *
+ * 从 D1 数据库读取文件元数据，用 Bot Token 代理 Telegram 图片
+ * Bot Token 存在环境变量 WG_BOT_TOKENS 中，前端永远看不到
+ *
+ * 参数：
+ *   ?w=800      缩略图宽度（利用 CF Image Resizing，返回 WebP）
+ *   ?q=80       图片质量（默认80）
+ *
+ * 环境变量（CF Pages 设置）：
+ *   WG_BOT_TOKENS  JSON: { "-100xxxx": "botToken", ... }
+ *   DB             D1 数据库绑定（变量名固定为 DB）
+ */
+
+export async function onRequest(context) {
+  const { request, env, params } = context
+  const url = new URL(request.url)
+
+  // 拼接文件 key（支持多级路径）
+  const rawPath = params.path
+  const fileKey = Array.isArray(rawPath)
+    ? rawPath.map(decodeURIComponent).join('/')
+    : decodeURIComponent(rawPath || '')
+
+  if (!fileKey) {
+    return new Response('Missing file key', { status: 400 })
+  }
+
+  // 从 D1 查询文件元数据
+  let row
+  try {
+    const stmt = env.DB.prepare(
+      'SELECT TgFileId, TgChatId, TgBotToken, FileType, Width, Height FROM files WHERE id = ?'
+    )
+    const result = await stmt.bind(fileKey).first()
+    row = result
+  } catch (e) {
+    return new Response('D1 query error: ' + e.message, { status: 500 })
+  }
+
+  if (!row) {
+    return new Response('File not found', { status: 404 })
+  }
+
+  // 获取 Bot Token（优先从 WG_BOT_TOKENS 环境变量，其次用 D1 里存的，但不暴露给前端）
+  let botToken
+  try {
+    const tokenMap = JSON.parse(env.WG_BOT_TOKENS || '{}')
+    botToken = tokenMap[row.TgChatId] || row.TgBotToken
+  } catch {
+    botToken = row.TgBotToken
+  }
+
+  if (!botToken) {
+    return new Response('No bot token configured', { status: 500 })
+  }
+
+  // 调用 Telegram getFile API 获取真实文件路径
+  let tgFilePath
+  try {
+    const resp = await fetch(
+      `https://api.telegram.org/bot${botToken}/getFile?file_id=${row.TgFileId}`
+    )
+    const data = await resp.json()
+    if (!data.ok) {
+      return new Response('Telegram getFile failed', { status: 502 })
+    }
+    tgFilePath = data.result.file_path
+  } catch (e) {
+    return new Response('Telegram API error: ' + e.message, { status: 502 })
+  }
+
+  const originalUrl = `https://api.telegram.org/file/bot${botToken}/${tgFilePath}`
+
+  // 解析缩略图参数
+  const width = parseInt(url.searchParams.get('w') || '0')
+  const quality = parseInt(url.searchParams.get('q') || '80')
+
+  // 构建 fetch 选项（CF Image Resizing 无需付费套餐，在 Workers/Pages 中免费可用）
+  const fetchOptions = {}
+  if (width > 0) {
+    fetchOptions.cf = {
+      image: {
+        width,
+        quality,
+        format: 'webp'
+      }
+    }
+  }
+
+  let imgResp
+  try {
+    imgResp = await fetch(originalUrl, fetchOptions)
+  } catch (e) {
+    return new Response('Image fetch failed: ' + e.message, { status: 502 })
+  }
+
+  const headers = new Headers()
+  headers.set('Content-Type', width > 0 ? 'image/webp' : (row.FileType || 'image/jpeg'))
+  headers.set('Cache-Control', 'public, max-age=86400')
+  headers.set('Access-Control-Allow-Origin', '*')
+  if (row.Width) headers.set('X-Image-Width', String(row.Width))
+  if (row.Height) headers.set('X-Image-Height', String(row.Height))
+
+  return new Response(imgResp.body, { status: 200, headers })
+}

--- a/functions/api/random.js
+++ b/functions/api/random.js
@@ -1,0 +1,68 @@
+/**
+ * GET /api/random - 随机图接口（公开）
+ *
+ * 参数：
+ *   type         url(JSON) | img(直接输出图片流)
+ *   orientation  horizontal | vertical | square
+ *   style        风格大类
+ *   color        主色调
+ *   thumb        true(默认) | false
+ *   w            缩略图宽度（type=img时生效，默认1920）
+ */
+
+export async function onRequest(context) {
+  const { request, env } = context
+  const url = new URL(request.url)
+
+  const type = url.searchParams.get('type') || 'url'
+  const thumb = url.searchParams.get('thumb') !== 'false'
+  const w = parseInt(url.searchParams.get('w') || '1920')
+
+  // 复用 wallpapers 接口逻辑
+  const listUrl = new URL('/api/wallpapers', url.origin)
+  listUrl.searchParams.set('random', 'true')
+  listUrl.searchParams.set('limit', '1')
+  listUrl.searchParams.set('thumb', String(thumb))
+  listUrl.searchParams.set('thumb_width', String(w))
+
+  // 透传筛选参数
+  ;['orientation', 'style', 'color', 'tags'].forEach(k => {
+    const v = url.searchParams.get(k)
+    if (v) listUrl.searchParams.set(k, v)
+  })
+
+  const listResp = await fetch(listUrl.toString())
+  const listData = await listResp.json()
+
+  if (!listData.items || listData.items.length === 0) {
+    return new Response(JSON.stringify({ error: 'No matching images' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+    })
+  }
+
+  const item = listData.items[0]
+  const imageUrl = item.thumb_url || item.url
+
+  if (type === 'img') {
+    const imgResp = await fetch(imageUrl)
+    return new Response(imgResp.body, {
+      headers: {
+        'Content-Type': imgResp.headers.get('Content-Type') || 'image/webp',
+        'Cache-Control': 'no-cache',
+        'Access-Control-Allow-Origin': '*',
+        'X-Image-Id': item.id,
+        'X-Image-Style': item.style || '',
+        'X-Image-Color': item.color || ''
+      }
+    })
+  }
+
+  return new Response(JSON.stringify(item), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-cache'
+    }
+  })
+}

--- a/functions/api/wallpapers.js
+++ b/functions/api/wallpapers.js
@@ -1,0 +1,173 @@
+/**
+ * GET /api/wallpapers - 壁纸列表接口（公开，无需认证）
+ *
+ * D1 数据库表结构（ImgBed 存储）：
+ *   files 表: id(key), FileName, FileType, Width, Height,
+ *             Directory, Tags(JSON), Channel, ChannelName,
+ *             TgFileId, TgChatId, TimeStamp, ListType
+ *
+ * 查询参数：
+ *   orientation  horizontal | vertical | square
+ *   style        动漫_二次元 | 魅力_迷人 | 自然_风景 | 自制_艺术 | 游戏_玩具 | 安逸_自由 | 科幻_星云 | 程序_代码
+ *   color        偏蓝 | 灰_白 | 暗色 | 紫_粉 | 偏黄 | 偏绿 | 偏红 | 其他颜色
+ *   tags         额外标签，逗号分隔（模糊匹配）
+ *   page         页码（默认1）
+ *   limit        每页数量（默认30，最大100）
+ *   random       是否随机（true/false）
+ *   thumb        是否返回缩略图URL（true/false）
+ *   thumb_width  缩略图宽度（默认800）
+ */
+
+const ORIENTATION_TAG = {
+  horizontal: '横图',
+  vertical: '竖图',
+  square: '方图'
+}
+
+export async function onRequest(context) {
+  const { request, env } = context
+  const url = new URL(request.url)
+
+  if (request.method === 'OPTIONS') {
+    return corsResp()
+  }
+
+  const orientation = url.searchParams.get('orientation') || ''
+  const style = url.searchParams.get('style') || ''
+  const color = url.searchParams.get('color') || ''
+  const tagsParam = url.searchParams.get('tags') || ''
+  const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'))
+  const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get('limit') || '30')))
+  const isRandom = url.searchParams.get('random') === 'true'
+  const needThumb = url.searchParams.get('thumb') !== 'false'  // 默认开启缩略图
+  const thumbWidth = parseInt(url.searchParams.get('thumb_width') || '800')
+
+  // 构建 SQL WHERE 条件
+  // D1 中 Tags 字段存储为 JSON 数组字符串，用 LIKE 模糊匹配
+  const conditions = ["Channel = 'TelegramNew'", "ListType != 'Block'"]
+  const bindings = []
+
+  // 目录前缀匹配（利用 Directory 字段加速）
+  // Directory 格式: wallpaper/static/{方向}/{风格}/
+  let dirPrefix = 'wallpaper/static/'
+  if (orientation && ORIENTATION_TAG[orientation]) {
+    dirPrefix += ORIENTATION_TAG[orientation] + '/'
+    if (style) dirPrefix += style + '/'
+  } else if (style) {
+    // 无方向限制时，用 Tags 匹配
+    conditions.push("Tags LIKE ?")
+    bindings.push(`%"${style}"%`)
+  }
+
+  if (dirPrefix !== 'wallpaper/static/') {
+    conditions.push("Directory LIKE ?")
+    bindings.push(dirPrefix + '%')
+  }
+
+  // 颜色匹配（Tags[3]）
+  if (color) {
+    conditions.push("Tags LIKE ?")
+    bindings.push(`%"${color}"%`)
+  }
+
+  // 额外标签匹配
+  if (tagsParam) {
+    tagsParam.split(',').forEach(tag => {
+      const t = tag.trim()
+      if (t) {
+        conditions.push("Tags LIKE ?")
+        bindings.push(`%"${t}"%`)
+      }
+    })
+  }
+
+  const whereClause = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : ''
+
+  // 查询总数
+  let total = 0
+  try {
+    const countStmt = env.DB.prepare(`SELECT COUNT(*) as cnt FROM files ${whereClause}`)
+    const countResult = await countStmt.bind(...bindings).first()
+    total = countResult?.cnt || 0
+  } catch (e) {
+    return jsonResp({ error: 'D1 count error: ' + e.message }, 500)
+  }
+
+  // 查询数据
+  const offset = (page - 1) * limit
+  const orderBy = isRandom ? 'ORDER BY RANDOM()' : 'ORDER BY TimeStamp DESC'
+  const query = `
+    SELECT id, FileName, FileType, Width, Height, Directory, Tags,
+           ChannelName, TimeStamp, TgFileId, TgChatId
+    FROM files
+    ${whereClause}
+    ${orderBy}
+    LIMIT ? OFFSET ?
+  `
+
+  let rows = []
+  try {
+    const stmt = env.DB.prepare(query)
+    const result = await stmt.bind(...bindings, limit, offset).all()
+    rows = result.results || []
+  } catch (e) {
+    return jsonResp({ error: 'D1 query error: ' + e.message }, 500)
+  }
+
+  // 构建返回数据
+  const baseUrl = `${url.protocol}//${url.host}`
+  const items = rows.map(row => {
+    let tags = []
+    try {
+      tags = JSON.parse(row.Tags || '[]')
+    } catch {}
+
+    const encodedKey = encodeURIComponent(row.id)
+    const origUrl = `${baseUrl}/api/file/${encodedKey}`
+    const thumbUrl = needThumb ? `${origUrl}?w=${thumbWidth}` : origUrl
+
+    return {
+      id: row.id,
+      url: origUrl,
+      thumb_url: thumbUrl,
+      width: row.Width,
+      height: row.Height,
+      orientation: tags[1] || 'unknown',
+      style: tags[2] || '',
+      color: tags[3] || '',
+      tags: tags.slice(4),
+      fileName: row.FileName,
+      timeStamp: row.TimeStamp,
+      channel: row.ChannelName
+    }
+  })
+
+  return jsonResp({
+    total,
+    page,
+    limit,
+    totalPages: Math.ceil(total / limit),
+    items
+  })
+}
+
+function jsonResp(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-cache'
+    }
+  })
+}
+
+function corsResp() {
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    }
+  })
+}

--- a/src/services/imgbed/api.js
+++ b/src/services/imgbed/api.js
@@ -1,0 +1,175 @@
+/**
+ * src/services/imgbed/api.js
+ *
+ * 从自建 /api/wallpapers 接口获取数据，替代原有从 CDN JSON 读取的方式。
+ * 保持与原项目 wallpaperStore.js 期望的数据格式兼容。
+ *
+ * 分类体系（来自你的实际数据）：
+ *   方向: 横图 / 竖图 / 方图
+ *   风格: 动漫_二次元 / 魅力_迷人 / 自然_风景 / 自制_艺术 /
+ *          游戏_玩具 / 安逸_自由 / 科幻_星云 / 程序_代码
+ *   颜色: 偏蓝 / 灰_白 / 暗色 / 紫_粉 / 偏黄 / 偏绿 / 偏红 / 其他颜色
+ */
+
+// ======== 分类元数据 ========
+
+export const STYLES = [
+  { key: '动漫_二次元', label: '动漫二次元', icon: '🎌' },
+  { key: '魅力_迷人',   label: '魅力迷人',   icon: '✨' },
+  { key: '自然_风景',   label: '自然风景',   icon: '🌿' },
+  { key: '自制_艺术',   label: '自制艺术',   icon: '🎨' },
+  { key: '游戏_玩具',   label: '游戏玩具',   icon: '🎮' },
+  { key: '安逸_自由',   label: '安逸自由',   icon: '🕊' },
+  { key: '科幻_星云',   label: '科幻星云',   icon: '🚀' },
+  { key: '程序_代码',   label: '程序代码',   icon: '💻' },
+]
+
+export const COLORS = [
+  { key: '偏蓝',   label: '偏蓝',   hex: '#60a5fa' },
+  { key: '灰_白',  label: '灰白',   hex: '#e2e8f0' },
+  { key: '暗色',   label: '暗色',   hex: '#374151' },
+  { key: '紫_粉',  label: '紫粉',   hex: '#c084fc' },
+  { key: '偏黄',   label: '偏黄',   hex: '#fbbf24' },
+  { key: '偏绿',   label: '偏绿',   hex: '#34d399' },
+  { key: '偏红',   label: '偏红',   hex: '#f87171' },
+  { key: '其他颜色', label: '其他', hex: '#94a3b8' },
+]
+
+export const ORIENTATIONS = [
+  { key: 'horizontal', label: '横图', tag: '横图' },
+  { key: 'vertical',   label: '竖图', tag: '竖图' },
+  { key: 'square',     label: '方图', tag: '方图' },
+]
+
+// ======== 数据映射：将 API 返回格式转换为原项目期望格式 ========
+
+/**
+ * 将 /api/wallpapers 返回的 item 转换为 wallpaperStore 期望的格式
+ */
+function toWallpaperItem(item) {
+  return {
+    id: item.id,
+    filename: item.fileName,
+    url: item.url,                  // 原图（代理）
+    thumbnailUrl: item.thumb_url,   // 缩略图（代理+压缩）
+    width: item.width,
+    height: item.height,
+    createdAt: item.timeStamp ? new Date(item.timeStamp).toISOString() : null,
+    tags: item.tags || [],
+    // 自定义扩展字段
+    _style: item.style,
+    _color: item.color,
+    _orientation: item.orientation,
+    _channel: item.channel,
+    // 兼容原项目的 category 字段
+    category: item.style || '',
+  }
+}
+
+// ======== 核心 API 函数 ========
+
+/**
+ * 获取壁纸列表
+ */
+export async function fetchWallpapers(opts = {}) {
+  const params = new URLSearchParams()
+  if (opts.orientation) params.set('orientation', opts.orientation)
+  if (opts.style)       params.set('style', opts.style)
+  if (opts.color)       params.set('color', opts.color)
+  if (opts.tags)        params.set('tags', opts.tags)
+  params.set('page',        String(opts.page  || 1))
+  params.set('limit',       String(opts.limit || 30))
+  params.set('random',      opts.random ? 'true' : 'false')
+  params.set('thumb',       opts.thumb !== false ? 'true' : 'false')
+  params.set('thumb_width', String(opts.thumbWidth || 800))
+
+  const resp = await fetch(`/api/wallpapers?${params}`)
+  if (!resp.ok) throw new Error(`API ${resp.status}`)
+  const data = await resp.json()
+
+  return {
+    total:      data.total,
+    page:       data.page,
+    limit:      data.limit,
+    totalPages: data.totalPages,
+    items:      (data.items || []).map(toWallpaperItem),
+  }
+}
+
+/**
+ * 获取随机壁纸
+ */
+export async function fetchRandom(opts = {}) {
+  const params = new URLSearchParams()
+  params.set('type', opts.type || 'url')
+  if (opts.orientation) params.set('orientation', opts.orientation)
+  if (opts.style)       params.set('style', opts.style)
+  if (opts.color)       params.set('color', opts.color)
+  params.set('thumb', opts.thumb !== false ? 'true' : 'false')
+  if (opts.w) params.set('w', String(opts.w))
+
+  const resp = await fetch(`/api/random?${params}`)
+  if (!resp.ok) throw new Error(`API ${resp.status}`)
+
+  if (opts.type === 'img') return resp
+  const item = await resp.json()
+  return toWallpaperItem(item)
+}
+
+/**
+ * 获取指定风格的分类数据（模拟原项目的 loadCategory 行为）
+ */
+export async function loadStyleCategory(style, orientation = '') {
+  const result = await fetchWallpapers({
+    style,
+    orientation,
+    limit: 100,
+    thumb: true,
+    thumbWidth: 800,
+  })
+  return result.items
+}
+
+/**
+ * 获取系列索引（模拟原项目的 loadSeriesIndex 行为）
+ * 返回该系列下所有分类的概要信息
+ */
+export async function loadSeriesIndex(seriesId) {
+  // seriesId 映射到方向
+  const orientationMap = {
+    desktop: 'horizontal',
+    mobile:  'vertical',
+    avatar:  'square',
+  }
+  const orientation = orientationMap[seriesId] || ''
+
+  // 获取各风格的数量
+  const categories = await Promise.all(
+    STYLES.map(async s => {
+      try {
+        const r = await fetchWallpapers({ orientation, style: s.key, limit: 1 })
+        return { key: s.key, label: s.label, icon: s.icon, total: r.total }
+      } catch {
+        return { key: s.key, label: s.label, icon: s.icon, total: 0 }
+      }
+    })
+  )
+
+  return {
+    series: seriesId,
+    categories: categories.filter(c => c.total > 0),
+  }
+}
+
+/**
+ * 获取图片代理URL
+ */
+export function getImageUrl(fileKey, opts = {}) {
+  const encoded = encodeURIComponent(fileKey)
+  let url = `/api/file/${encoded}`
+  const params = new URLSearchParams()
+  if (opts.w) params.set('w', String(opts.w))
+  if (opts.q) params.set('q', String(opts.q))
+  const qs = params.toString()
+  return qs ? `${url}?${qs}` : url
+}

--- a/src/stores/imgbed.js
+++ b/src/stores/imgbed.js
@@ -1,0 +1,141 @@
+/**
+ * src/stores/imgbed.js
+ *
+ * 替代 wallpaperStore 中从 CDN JSON 加载数据的逻辑。
+ * 提供相同的接口，从自建 /api/wallpapers 读取数据。
+ *
+ * 使用方式：
+ *   在需要获取壁纸数据的地方，改为调用此 store 的方法，
+ *   或直接调用 src/services/imgbed/api.js 中的函数。
+ */
+
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { fetchWallpapers, fetchRandom, STYLES, COLORS, ORIENTATIONS } from '@/services/imgbed/api'
+
+export const useImgbedStore = defineStore('imgbed', () => {
+  // ======== State ========
+  const wallpapers = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+  const total = ref(0)
+  const currentPage = ref(1)
+  const totalPages = ref(1)
+
+  // 当前筛选条件
+  const filters = ref({
+    orientation: '',   // horizontal | vertical | square
+    style: '',         // 动漫_二次元 等
+    color: '',         // 偏蓝 等
+    tags: '',          // 额外标签
+  })
+
+  // 分类元数据（供筛选面板使用）
+  const CATEGORY_META = { STYLES, COLORS, ORIENTATIONS }
+
+  // ======== Getters ========
+  const loaded = computed(() => wallpapers.value.length > 0)
+  const hasMore = computed(() => currentPage.value < totalPages.value)
+
+  // ======== Actions ========
+
+  /**
+   * 加载壁纸列表（替换原 initSeries 逻辑）
+   */
+  async function loadWallpapers(opts = {}) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const result = await fetchWallpapers({
+        ...filters.value,
+        ...opts,
+        page: opts.page || 1,
+        limit: opts.limit || 30,
+        thumb: true,
+        thumbWidth: 800,
+      })
+
+      wallpapers.value = opts.append
+        ? [...wallpapers.value, ...result.items]
+        : result.items
+
+      total.value = result.total
+      currentPage.value = result.page
+      totalPages.value = result.totalPages
+    } catch (e) {
+      error.value = e.message
+      console.error('[ImgbedStore] loadWallpapers failed:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * 加载下一页（追加模式）
+   */
+  async function loadMore() {
+    if (!hasMore.value || loading.value) return
+    await loadWallpapers({ page: currentPage.value + 1, append: true })
+  }
+
+  /**
+   * 设置筛选条件并重新加载
+   */
+  async function applyFilters(newFilters) {
+    filters.value = { ...filters.value, ...newFilters }
+    currentPage.value = 1
+    await loadWallpapers({ page: 1 })
+  }
+
+  /**
+   * 清除筛选条件
+   */
+  async function clearFilters() {
+    filters.value = { orientation: '', style: '', color: '', tags: '' }
+    await loadWallpapers({ page: 1 })
+  }
+
+  /**
+   * 获取随机壁纸
+   */
+  async function getRandomWallpaper(opts = {}) {
+    return fetchRandom({ ...filters.value, ...opts })
+  }
+
+  /**
+   * 重置 store
+   */
+  function reset() {
+    wallpapers.value = []
+    loading.value = false
+    error.value = null
+    total.value = 0
+    currentPage.value = 1
+    totalPages.value = 1
+    filters.value = { orientation: '', style: '', color: '', tags: '' }
+  }
+
+  return {
+    // State
+    wallpapers,
+    loading,
+    error,
+    total,
+    currentPage,
+    totalPages,
+    filters,
+    // Getters
+    loaded,
+    hasMore,
+    // Meta
+    CATEGORY_META,
+    // Actions
+    loadWallpapers,
+    loadMore,
+    applyFilters,
+    clearFilters,
+    getRandomWallpaper,
+    reset,
+  }
+})

--- a/src/views/admin/index.html
+++ b/src/views/admin/index.html
@@ -1,0 +1,839 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>壁纸库 · 管理后台</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --bg: #0a0a0f;
+    --bg2: #111118;
+    --bg3: #1a1a24;
+    --border: #2a2a3a;
+    --accent: #6c63ff;
+    --accent2: #a78bfa;
+    --text: #e2e2f0;
+    --text2: #9090b0;
+    --text3: #5a5a7a;
+    --green: #34d399;
+    --red: #f87171;
+    --yellow: #fbbf24;
+    --radius: 10px;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Noto Sans SC', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+  }
+
+  /* ---- 侧边栏 ---- */
+  .sidebar {
+    width: 220px;
+    background: var(--bg2);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0; left: 0; bottom: 0;
+    z-index: 100;
+  }
+
+  .sidebar-logo {
+    padding: 24px 20px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .sidebar-logo h1 {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--accent2);
+    letter-spacing: 0.05em;
+  }
+  .sidebar-logo p {
+    font-size: 11px;
+    color: var(--text3);
+    margin-top: 3px;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .nav {
+    padding: 12px 10px;
+    flex: 1;
+  }
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
+    border-radius: 7px;
+    cursor: pointer;
+    font-size: 13.5px;
+    color: var(--text2);
+    transition: all 0.15s;
+    margin-bottom: 2px;
+  }
+  .nav-item:hover { background: var(--bg3); color: var(--text); }
+  .nav-item.active { background: rgba(108,99,255,0.15); color: var(--accent2); }
+  .nav-item .icon { font-size: 16px; width: 20px; text-align: center; }
+
+  .sidebar-bottom {
+    padding: 12px 10px;
+    border-top: 1px solid var(--border);
+  }
+  .logout-btn {
+    width: 100%;
+    padding: 8px 12px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text3);
+    cursor: pointer;
+    font-size: 13px;
+    transition: all 0.15s;
+  }
+  .logout-btn:hover { border-color: var(--red); color: var(--red); }
+
+  /* ---- 主内容 ---- */
+  .main {
+    margin-left: 220px;
+    flex: 1;
+    padding: 32px 36px;
+    max-width: calc(100vw - 220px);
+  }
+
+  .page-header {
+    margin-bottom: 28px;
+  }
+  .page-header h2 {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .page-header p {
+    color: var(--text3);
+    font-size: 13px;
+    margin-top: 4px;
+  }
+
+  /* ---- 卡片 ---- */
+  .card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    margin-bottom: 20px;
+  }
+  .card-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text2);
+    margin-bottom: 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .card-title::before {
+    content: '';
+    width: 3px; height: 14px;
+    background: var(--accent);
+    border-radius: 2px;
+  }
+
+  /* ---- 表单 ---- */
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+  }
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .form-group label {
+    font-size: 12px;
+    color: var(--text2);
+    font-weight: 500;
+  }
+  .form-group .hint {
+    font-size: 11px;
+    color: var(--text3);
+    margin-top: 2px;
+  }
+  input[type="text"], input[type="password"], input[type="number"], select {
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text);
+    padding: 9px 12px;
+    font-size: 13px;
+    font-family: inherit;
+    width: 100%;
+    transition: border-color 0.15s;
+  }
+  input:focus, select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  select option { background: var(--bg3); }
+
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .toggle-row:last-child { border-bottom: none; }
+  .toggle-label { font-size: 13.5px; }
+  .toggle-desc { font-size: 11px; color: var(--text3); margin-top: 2px; }
+
+  .toggle {
+    position: relative;
+    width: 40px; height: 22px;
+    flex-shrink: 0;
+  }
+  .toggle input { opacity: 0; width: 0; height: 0; }
+  .toggle-slider {
+    position: absolute;
+    inset: 0;
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    border-radius: 11px;
+    cursor: pointer;
+    transition: 0.2s;
+  }
+  .toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 16px; height: 16px;
+    left: 2px; top: 2px;
+    background: var(--text3);
+    border-radius: 50%;
+    transition: 0.2s;
+  }
+  .toggle input:checked + .toggle-slider { background: var(--accent); border-color: var(--accent); }
+  .toggle input:checked + .toggle-slider::before {
+    transform: translateX(18px);
+    background: white;
+  }
+
+  /* ---- 按钮 ---- */
+  .btn {
+    padding: 9px 20px;
+    border-radius: 7px;
+    font-size: 13.5px;
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: none;
+  }
+  .btn-primary { background: var(--accent); color: white; }
+  .btn-primary:hover { background: #5b53ee; }
+  .btn-secondary { background: var(--bg3); color: var(--text2); border: 1px solid var(--border); }
+  .btn-secondary:hover { color: var(--text); border-color: var(--text3); }
+  .btn-danger { background: transparent; color: var(--red); border: 1px solid var(--red); }
+  .btn-danger:hover { background: var(--red); color: white; }
+
+  .btn-row {
+    display: flex;
+    gap: 10px;
+    margin-top: 20px;
+    align-items: center;
+  }
+
+  /* ---- 状态标签 ---- */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .badge-green { background: rgba(52,211,153,0.1); color: var(--green); }
+  .badge-yellow { background: rgba(251,191,36,0.1); color: var(--yellow); }
+  .badge-red { background: rgba(248,113,113,0.1); color: var(--red); }
+
+  /* ---- 统计卡片 ---- */
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 14px;
+    margin-bottom: 24px;
+  }
+  .stat-card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px 20px;
+  }
+  .stat-value {
+    font-size: 26px;
+    font-weight: 700;
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--accent2);
+  }
+  .stat-label { font-size: 12px; color: var(--text3); margin-top: 4px; }
+
+  /* ---- API 测试面板 ---- */
+  .api-url-bar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .api-url-bar input {
+    flex: 1;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+  }
+  .api-result {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 14px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11.5px;
+    color: var(--text2);
+    min-height: 80px;
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .api-preview-img {
+    max-width: 100%;
+    max-height: 300px;
+    border-radius: 7px;
+    margin-top: 10px;
+    display: none;
+  }
+
+  /* ---- 筛选标签多选 ---- */
+  .tag-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+  }
+  .tag-opt {
+    padding: 5px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    background: var(--bg3);
+    border: 1px solid var(--border);
+    color: var(--text2);
+    transition: all 0.15s;
+    user-select: none;
+  }
+  .tag-opt:hover { border-color: var(--accent); color: var(--text); }
+  .tag-opt.selected { background: rgba(108,99,255,0.15); border-color: var(--accent); color: var(--accent2); }
+
+  /* ---- 登录页 ---- */
+  #login-page {
+    position: fixed;
+    inset: 0;
+    background: var(--bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+  }
+  .login-card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 40px;
+    width: 360px;
+  }
+  .login-card h2 {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  .login-card p {
+    font-size: 13px;
+    color: var(--text3);
+    margin-bottom: 28px;
+  }
+  .login-card .form-group { margin-bottom: 14px; }
+  .login-card .btn { width: 100%; margin-top: 8px; padding: 11px; }
+  .login-error {
+    color: var(--red);
+    font-size: 12px;
+    margin-top: 8px;
+    display: none;
+  }
+
+  /* ---- 吐司提示 ---- */
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    padding: 12px 20px;
+    border-radius: 9px;
+    font-size: 13.5px;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: all 0.25s;
+    z-index: 9999;
+    pointer-events: none;
+  }
+  .toast.show { opacity: 1; transform: translateY(0); }
+  .toast.success { background: rgba(52,211,153,0.15); color: var(--green); border: 1px solid rgba(52,211,153,0.3); }
+  .toast.error { background: rgba(248,113,113,0.15); color: var(--red); border: 1px solid rgba(248,113,113,0.3); }
+
+  /* 分页隐藏时 */
+  .page-section { display: none; }
+  .page-section.active { display: block; }
+</style>
+</head>
+<body>
+
+<!-- 登录页 -->
+<div id="login-page">
+  <div class="login-card">
+    <h2>管理后台</h2>
+    <p>壁纸库 · WallpaperGallery Admin</p>
+    <div class="form-group">
+      <label>用户名</label>
+      <input type="text" id="login-user" placeholder="admin" />
+    </div>
+    <div class="form-group">
+      <label>密码</label>
+      <input type="password" id="login-pass" placeholder="••••••••" onkeydown="if(event.key==='Enter')doLogin()" />
+    </div>
+    <div class="login-error" id="login-error">用户名或密码错误</div>
+    <button class="btn btn-primary" onclick="doLogin()">登录</button>
+  </div>
+</div>
+
+<!-- 侧边栏 -->
+<div class="sidebar">
+  <div class="sidebar-logo">
+    <h1>🖼 壁纸库</h1>
+    <p>Admin Dashboard</p>
+  </div>
+  <nav class="nav">
+    <div class="nav-item active" onclick="showPage('overview')" id="nav-overview">
+      <span class="icon">📊</span> 概览
+    </div>
+    <div class="nav-item" onclick="showPage('api-config')" id="nav-api-config">
+      <span class="icon">⚙️</span> API 配置
+    </div>
+    <div class="nav-item" onclick="showPage('api-test')" id="nav-api-test">
+      <span class="icon">🧪</span> API 测试
+    </div>
+    <div class="nav-item" onclick="showPage('bot-config')" id="nav-bot-config">
+      <span class="icon">🤖</span> Bot 配置
+    </div>
+  </nav>
+  <div class="sidebar-bottom">
+    <button class="logout-btn" onclick="doLogout()">退出登录</button>
+  </div>
+</div>
+
+<!-- 主内容 -->
+<div class="main">
+
+  <!-- 概览 -->
+  <div class="page-section active" id="page-overview">
+    <div class="page-header">
+      <h2>数据概览</h2>
+      <p>壁纸库当前数据统计</p>
+    </div>
+    <div class="stats-grid" id="stats-grid">
+      <div class="stat-card"><div class="stat-value" id="stat-total">-</div><div class="stat-label">总图片数</div></div>
+      <div class="stat-card"><div class="stat-value" id="stat-h">-</div><div class="stat-label">横图</div></div>
+      <div class="stat-card"><div class="stat-value" id="stat-v">-</div><div class="stat-label">竖图</div></div>
+      <div class="stat-card"><div class="stat-value" id="stat-s">-</div><div class="stat-label">方图</div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">风格分布</div>
+      <div id="style-dist" style="display:flex;flex-wrap:wrap;gap:10px;"></div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">颜色分布</div>
+      <div id="color-dist" style="display:flex;flex-wrap:wrap;gap:10px;"></div>
+    </div>
+  </div>
+
+  <!-- API 配置 -->
+  <div class="page-section" id="page-api-config">
+    <div class="page-header">
+      <h2>API 配置</h2>
+      <p>配置对外公开的图片 API 行为，修改后立即生效</p>
+    </div>
+
+    <div class="card">
+      <div class="card-title">随机图 API 设置</div>
+      <div class="toggle-row">
+        <div>
+          <div class="toggle-label">启用随机图 API</div>
+          <div class="toggle-desc">关闭后 /api/random 返回 403</div>
+        </div>
+        <label class="toggle"><input type="checkbox" id="cfg-random-enabled" checked><span class="toggle-slider"></span></label>
+      </div>
+      <div class="toggle-row">
+        <div>
+          <div class="toggle-label">默认返回缩略图</div>
+          <div class="toggle-desc">type=img 时，默认压缩为 WebP 输出</div>
+        </div>
+        <label class="toggle"><input type="checkbox" id="cfg-default-thumb" checked><span class="toggle-slider"></span></label>
+      </div>
+      <div class="form-grid" style="margin-top:16px">
+        <div class="form-group">
+          <label>缩略图默认宽度（px）</label>
+          <input type="number" id="cfg-thumb-width" value="1920" min="400" max="3840" />
+          <div class="hint">推荐：背景图 1920，展示图 800，头图 400</div>
+        </div>
+        <div class="form-group">
+          <label>默认方向筛选</label>
+          <select id="cfg-default-orientation">
+            <option value="">不限</option>
+            <option value="horizontal">横图</option>
+            <option value="vertical">竖图</option>
+            <option value="square">方图</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">默认风格筛选</div>
+      <p style="font-size:12px;color:var(--text3);margin-bottom:12px">选中的风格会被包含在随机图返回范围内（不选=全部）</p>
+      <div class="tag-group" id="style-tags"></div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">默认颜色筛选</div>
+      <p style="font-size:12px;color:var(--text3);margin-bottom:12px">选中的颜色会被包含在随机图返回范围内（不选=全部）</p>
+      <div class="tag-group" id="color-tags"></div>
+    </div>
+
+    <div class="btn-row">
+      <button class="btn btn-primary" onclick="saveConfig()">保存配置</button>
+      <button class="btn btn-secondary" onclick="loadConfig()">重置</button>
+    </div>
+  </div>
+
+  <!-- API 测试 -->
+  <div class="page-section" id="page-api-test">
+    <div class="page-header">
+      <h2>API 测试</h2>
+      <p>在线测试各接口，验证配置是否生效</p>
+    </div>
+
+    <div class="card">
+      <div class="card-title">快捷测试</div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px">
+        <button class="btn btn-secondary" onclick="testApi('/api/random?type=url')">随机图(JSON)</button>
+        <button class="btn btn-secondary" onclick="testApi('/api/random?type=img','img')">随机图(直出)</button>
+        <button class="btn btn-secondary" onclick="testApi('/api/random?type=img&orientation=horizontal','img')">横图随机</button>
+        <button class="btn btn-secondary" onclick="testApi('/api/random?type=img&style=自然_风景','img')">自然风景</button>
+        <button class="btn btn-secondary" onclick="testApi('/api/random?type=img&color=暗色','img')">暗色系</button>
+        <button class="btn btn-secondary" onclick="testApi('/api/wallpapers?limit=5')">图片列表</button>
+      </div>
+      <div class="api-url-bar">
+        <input type="text" id="api-url-input" placeholder="输入 API 路径，如 /api/random?type=url" />
+        <button class="btn btn-primary" onclick="testApiCustom()">发送</button>
+      </div>
+      <div class="api-result" id="api-result">点击上方按钮测试 API...</div>
+      <img class="api-preview-img" id="api-preview" />
+    </div>
+
+    <div class="card">
+      <div class="card-title">API 文档</div>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--text2);line-height:2">
+        <div><span style="color:var(--accent2)">GET</span> /api/wallpapers<span style="color:var(--text3)">?orientation=horizontal&style=自然_风景&color=偏蓝&page=1&limit=30</span></div>
+        <div><span style="color:var(--accent2)">GET</span> /api/random<span style="color:var(--text3)">?type=url|img&orientation=&style=&color=&thumb=true&w=1920</span></div>
+        <div><span style="color:var(--accent2)">GET</span> /api/file/&lt;key&gt;<span style="color:var(--text3)">?w=800&q=80</span></div>
+        <div style="margin-top:12px;color:var(--text3)">
+          orientation: horizontal | vertical | square<br>
+          style: 动漫_二次元 | 魅力_迷人 | 自然_风景 | 自制_艺术 | 游戏_玩具 | 安逸_自由 | 科幻_星云 | 程序_代码<br>
+          color: 偏蓝 | 灰_白 | 暗色 | 紫_粉 | 偏黄 | 偏绿 | 偏红 | 其他颜色
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bot 配置 -->
+  <div class="page-section" id="page-bot-config">
+    <div class="page-header">
+      <h2>Bot 配置</h2>
+      <p>配置 Telegram Bot Token 与频道映射（存储在环境变量中，此处仅查看状态）</p>
+    </div>
+    <div class="card">
+      <div class="card-title">环境变量说明</div>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--text2);line-height:2.2">
+        <div>在 <span style="color:var(--accent2)">CF Pages → 设置 → 环境变量</span> 中配置以下变量：</div>
+        <div style="margin-top:10px">
+          <div><span style="color:var(--yellow)">WG_BOT_TOKENS</span> <span style="color:var(--text3)">= JSON格式，chatId 映射到 botToken</span></div>
+          <div style="color:var(--text3);margin-left:16px">{"−1003814998799":"YOUR_BOT_TOKEN_1","−1003777271568":"YOUR_BOT_TOKEN_2","−1003718954682":"YOUR_BOT_TOKEN_3"}</div>
+          <div style="margin-top:8px"><span style="color:var(--yellow)">ADMIN_USER</span> <span style="color:var(--text3)">= 管理员用户名</span></div>
+          <div style="margin-top:2px"><span style="color:var(--yellow)">ADMIN_PASS</span> <span style="color:var(--text3)">= 管理员密码</span></div>
+          <div style="margin-top:2px"><span style="color:var(--yellow)">ADMIN_SECRET</span> <span style="color:var(--text3)">= JWT 签名密钥（32位随机字符串）</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-title">频道状态检测</div>
+      <button class="btn btn-secondary" onclick="checkBots()" style="margin-bottom:14px">检测频道连通性</button>
+      <div id="bot-status"></div>
+    </div>
+  </div>
+
+</div>
+
+<!-- 吐司 -->
+<div class="toast" id="toast"></div>
+
+<script>
+// =========== 数据 ===========
+const STYLES = ['动漫_二次元','魅力_迷人','自然_风景','自制_艺术','游戏_玩具','安逸_自由','科幻_星云','程序_代码']
+const COLORS = ['偏蓝','灰_白','暗色','紫_粉','偏黄','偏绿','偏红','其他颜色']
+
+let currentConfig = {}
+
+// =========== 登录 ===========
+async function doLogin() {
+  const user = document.getElementById('login-user').value
+  const pass = document.getElementById('login-pass').value
+  const err = document.getElementById('login-error')
+  err.style.display = 'none'
+
+  try {
+    const resp = await fetch('/api/admin/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: user, password: pass }),
+      credentials: 'include'
+    })
+    const data = await resp.json()
+    if (data.success) {
+      document.getElementById('login-page').style.display = 'none'
+      init()
+    } else {
+      err.style.display = 'block'
+    }
+  } catch (e) {
+    err.textContent = '请求失败：' + e.message
+    err.style.display = 'block'
+  }
+}
+
+async function doLogout() {
+  await fetch('/api/admin/auth?action=logout', { credentials: 'include' })
+  location.reload()
+}
+
+// =========== 初始化 ===========
+async function init() {
+  // 验证会话
+  try {
+    const r = await fetch('/api/admin/verify', { credentials: 'include' })
+    const d = await r.json()
+    if (!d.valid) { document.getElementById('login-page').style.display = 'flex'; return }
+    document.getElementById('login-page').style.display = 'none'
+  } catch {}
+
+  loadOverview()
+  loadConfig()
+  buildTagSelectors()
+}
+
+// =========== 概览 ===========
+async function loadOverview() {
+  try {
+    const resp = await fetch('/api/wallpapers?limit=1')
+    const data = await resp.json()
+    document.getElementById('stat-total').textContent = data.total?.toLocaleString() || '-'
+
+    const [rH, rV, rS] = await Promise.all([
+      fetch('/api/wallpapers?orientation=horizontal&limit=1').then(r=>r.json()),
+      fetch('/api/wallpapers?orientation=vertical&limit=1').then(r=>r.json()),
+      fetch('/api/wallpapers?orientation=square&limit=1').then(r=>r.json()),
+    ])
+    document.getElementById('stat-h').textContent = rH.total?.toLocaleString() || '-'
+    document.getElementById('stat-v').textContent = rV.total?.toLocaleString() || '-'
+    document.getElementById('stat-s').textContent = rS.total?.toLocaleString() || '-'
+
+    // 风格分布
+    const styleDist = document.getElementById('style-dist')
+    styleDist.innerHTML = ''
+    for (const s of STYLES) {
+      const r = await fetch(`/api/wallpapers?style=${encodeURIComponent(s)}&limit=1`).then(r=>r.json())
+      const div = document.createElement('div')
+      div.style.cssText = 'display:flex;align-items:center;gap:8px;padding:6px 14px;background:var(--bg3);border-radius:20px;font-size:13px'
+      div.innerHTML = `<span style="color:var(--text2)">${s}</span><span style="color:var(--accent2);font-family:'JetBrains Mono',monospace;font-size:12px">${r.total}</span>`
+      styleDist.appendChild(div)
+    }
+  } catch(e) { console.error(e) }
+}
+
+// =========== API 配置 ===========
+async function loadConfig() {
+  try {
+    const resp = await fetch('/api/admin/config', { credentials: 'include' })
+    const data = await resp.json()
+    currentConfig = data
+
+    document.getElementById('cfg-random-enabled').checked = data.randomApi?.enabled !== false
+    document.getElementById('cfg-default-thumb').checked = data.randomApi?.defaultThumb !== false
+    document.getElementById('cfg-thumb-width').value = data.randomApi?.defaultThumbWidth || 1920
+    document.getElementById('cfg-default-orientation').value = data.randomApi?.defaultOrientation || ''
+
+    // 标签选中状态
+    updateTagSelection('style-tags', STYLES, data.randomApi?.defaultStyles || [])
+    updateTagSelection('color-tags', COLORS, data.randomApi?.defaultColors || [])
+  } catch(e) { console.error(e) }
+}
+
+function buildTagSelectors() {
+  const styleEl = document.getElementById('style-tags')
+  const colorEl = document.getElementById('color-tags')
+  styleEl.innerHTML = STYLES.map(s => `<div class="tag-opt" onclick="toggleTag(this,'style-tags')" data-val="${s}">${s}</div>`).join('')
+  colorEl.innerHTML = COLORS.map(c => `<div class="tag-opt" onclick="toggleTag(this,'color-tags')" data-val="${c}">${c}</div>`).join('')
+}
+
+function updateTagSelection(containerId, allTags, selectedTags) {
+  const container = document.getElementById(containerId)
+  container.innerHTML = allTags.map(t => {
+    const sel = selectedTags.length === 0 || selectedTags.includes(t) ? 'selected' : ''
+    return `<div class="tag-opt ${sel}" onclick="toggleTag(this,'${containerId}')" data-val="${t}">${t}</div>`
+  }).join('')
+}
+
+function toggleTag(el) {
+  el.classList.toggle('selected')
+}
+
+async function saveConfig() {
+  const selectedStyles = [...document.querySelectorAll('#style-tags .tag-opt.selected')].map(el => el.dataset.val)
+  const selectedColors = [...document.querySelectorAll('#color-tags .tag-opt.selected')].map(el => el.dataset.val)
+
+  const config = {
+    randomApi: {
+      enabled: document.getElementById('cfg-random-enabled').checked,
+      defaultThumb: document.getElementById('cfg-default-thumb').checked,
+      defaultThumbWidth: parseInt(document.getElementById('cfg-thumb-width').value),
+      defaultOrientation: document.getElementById('cfg-default-orientation').value,
+      defaultStyles: selectedStyles.length === STYLES.length ? [] : selectedStyles,
+      defaultColors: selectedColors.length === COLORS.length ? [] : selectedColors
+    }
+  }
+
+  try {
+    const resp = await fetch('/api/admin/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+      credentials: 'include'
+    })
+    const data = await resp.json()
+    if (data.success) {
+      showToast('配置已保存', 'success')
+    } else {
+      showToast('保存失败：' + (data.error || ''), 'error')
+    }
+  } catch(e) {
+    showToast('请求失败：' + e.message, 'error')
+  }
+}
+
+// =========== API 测试 ===========
+async function testApi(path, mode='json') {
+  document.getElementById('api-url-input').value = path
+  await executeTest(path, mode)
+}
+
+async function testApiCustom() {
+  const path = document.getElementById('api-url-input').value.trim()
+  if (!path) return
+  const mode = path.includes('type=img') ? 'img' : 'json'
+  await executeTest(path, mode)
+}
+
+async function executeTest(path, mode) {
+  const resultEl = document.getElementById('api-result')
+  const previewEl = document.getElementById('api-preview')
+  resultEl.textContent = '请求中...'
+  previewEl.style.display = 'none'
+
+  try {
+    const start = Date.now()
+    const resp = await fetch(path)
+    const elapsed = Date.now() - start
+
+    if (mode === 'img') {
+      const blob = await resp.blob()
+      const objUrl = URL.createObjectURL(blob)
+      previewEl.src = objUrl
+      previewEl.style.display = 'block'
+      resultEl.textContent = `HTTP ${resp.status} · ${elapsed}ms · ${(blob.size/1024).toFixed(1)}KB · ${blob.type}`
+    } else {
+      const text = await resp.text()
+      let formatted
+      try { formatted = JSON.stringify(JSON.parse(text), null, 2) }
+      catch { formatted = text }
+      resultEl.textContent = `HTTP ${resp.status} · ${elapsed}ms\n\n${formatted}`
+    }
+  } catch(e) {
+    resultEl.textContent = '请求失败：' + e.message
+  }
+}
+
+// =========== Bot 检测 ===========
+async function checkBots() {
+  const el = document.getElementById('bot-status')
+  el.innerHTML = '<div style="color:var(--text3);font-size:13px">检测中...</div>'
+  try {
+    const resp = await fetch('/api/random?type=url')
+    const data = await resp.json()
+    el.innerHTML = resp.ok
+      ? `<div class="badge badge-green">✓ 随机图 API 正常</div><div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text3);margin-top:8px">${data.id || ''}</div>`
+      : `<div class="badge badge-red">✗ 异常：${data.error || resp.status}</div>`
+  } catch(e) {
+    el.innerHTML = `<div class="badge badge-red">✗ 请求失败：${e.message}</div>`
+  }
+}
+
+// =========== 工具 ===========
+function showPage(name) {
+  document.querySelectorAll('.page-section').forEach(el => el.classList.remove('active'))
+  document.querySelectorAll('.nav-item').forEach(el => el.classList.remove('active'))
+  document.getElementById('page-' + name).classList.add('active')
+  document.getElementById('nav-' + name).classList.add('active')
+}
+
+function showToast(msg, type='success') {
+  const el = document.getElementById('toast')
+  el.textContent = msg
+  el.className = `toast ${type} show`
+  setTimeout(() => { el.classList.remove('show') }, 2500)
+}
+
+// 初始检测会话
+window.onload = () => {
+  fetch('/api/admin/verify', { credentials: 'include' })
+    .then(r => r.json())
+    .then(d => {
+      if (d.valid) {
+        document.getElementById('login-page').style.display = 'none'
+        init()
+      }
+    })
+    .catch(() => {})
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
- functions/api/file/[[path]].js: image proxy hiding Bot Token, supports ?w= thumbnail
- functions/api/wallpapers.js: wallpaper list API querying D1 directly
- functions/api/random.js: random image API with filter support
- functions/api/admin/auth.js: admin login/logout/verify (HMAC session)
- functions/api/admin/config.js: API config CRUD stored in D1 settings table
- functions/admin.js: admin panel route
- src/services/imgbed/api.js: data service layer replacing CDN JSON source
- src/stores/imgbed.js: Pinia store for imgbed API
- src/views/admin/index.html: admin dashboard (overview/api-config/test/bot)
- CUSTOM_DEPLOY.md: deployment guide

Data source: Cloudflare D1 (shared with ImgBed)
Bot Token: stored in WG_BOT_TOKENS env var, never exposed to frontend
Thumbnail: CF Image Resizing via ?w=<width> parameter